### PR TITLE
Break lines before hitting width limit, and preserve whitespace

### DIFF
--- a/wordwrap.go
+++ b/wordwrap.go
@@ -36,7 +36,7 @@ func WrapString(s string, lim uint) string {
 			}
 
 			// If this whitespace would put us over the limit, break
-			if current + uint(spaceBuf.Len()) >= lim {
+			if current+uint(spaceBuf.Len()) >= lim {
 				goto LINEBREAK
 			}
 

--- a/wordwrap.go
+++ b/wordwrap.go
@@ -15,16 +15,28 @@ func WrapString(s string, lim uint) string {
 	// Initialize a buffer with a slightly larger size to account for breaks
 	init := make([]byte, 0, len(s))
 	buf := bytes.NewBuffer(init)
+	implicit := false
 
 	var current uint
 	var spaceBuf bytes.Buffer
 	for _, char := range s {
 		current++
 
+		// If we got a newline, then we honor it and output it. But we have
+		// to reset our limit count.
+		if char == '\n' {
+			if current == 1 && implicit {
+				current = 0
+				continue
+			}
+			implicit = false
+			goto LINEBREAK
+		}
+
 		// Track the whitespace in our whitespace buffer.
 		if unicode.IsSpace(char) {
 			// Consume any whitespace if we just linebroke implicitly.
-			if current == 1 {
+			if current == 1 && implicit {
 				current = 0
 				continue
 			}
@@ -32,22 +44,18 @@ func WrapString(s string, lim uint) string {
 			// If we're over the limit already, then output a newline
 			// and reset.
 			if current > lim {
+				implicit = true
 				goto LINEBREAK
 			}
 
 			// If this whitespace would put us over the limit, break
 			if current+uint(spaceBuf.Len()) >= lim {
+				implicit = true
 				goto LINEBREAK
 			}
 
 			spaceBuf.WriteRune(char)
 			continue
-		}
-
-		// If we got a newline, then we honor it and output it. But we have
-		// to reset our limit count.
-		if char == '\n' {
-			goto LINEBREAK
 		}
 
 		// Output our buffered whitespace if we have any

--- a/wordwrap_test.go
+++ b/wordwrap_test.go
@@ -39,6 +39,16 @@ func TestWrapString(t *testing.T) {
 			"foo\nb ar\nbaz",
 			4,
 		},
+		{
+			"fo sop       \nb ar\n baz",
+			"fo sop\nb ar\n baz",
+			4,
+		},
+		{
+			" This is a list:\n\n\t* foo\n\t* bar\n\n\n\t* baz\nBAM",
+			" This\nis a\nlist:\n\n\t* foo\n\t* bar\n\n\n\t* baz\nBAM",
+			4,
+		},
 	}
 
 	for _, tc := range cases {

--- a/wordwrap_test.go
+++ b/wordwrap_test.go
@@ -9,52 +9,77 @@ func TestWrapString(t *testing.T) {
 		Input, Output string
 		Lim           uint
 	}{
+		// A simple word passes through.
 		{
 			"foo",
 			"foo",
 			4,
 		},
+		// A single word that is too long passes through.
+		// We do not break words.
 		{
 			"foobarbaz",
 			"foobarbaz",
 			4,
 		},
+		// Lines are broken at whitespace.
 		{
 			"foo bar baz",
 			"foo\nbar\nbaz",
 			4,
 		},
+		// Lines are broken at whitespace, even if words
+		// are too long. We do not break words.
 		{
-			"foo\nb ar\nbaz",
-			"foo\nb ar\nbaz",
+			"foo bars bazzes",
+			"foo\nbars\nbazzes",
 			4,
 		},
+		// A word that would run beyond the width is wrapped.
 		{
-			"foo       \nb ar\nbaz",
-			"foo\nb ar\nbaz",
+			"fo sop",
+			"fo\nsop",
 			4,
 		},
+		// Whitespace that trails a line and fits the width
+		// passes through, as does whitespace prefixing an
+		// explicit line break. A tab counts as one character.
 		{
-			"foo       \nb ar\nbaz",
-			"foo\nb ar\nbaz",
+			"foo\nb\t r\n baz",
+			"foo\nb\t r\n baz",
 			4,
 		},
+		// Trailing whitespace is removed if it doesn't fit the width.
+		// Runs of whitespace on which a line is broken are removed.
 		{
-			"fo sop       \nb ar\n baz",
-			"fo sop\nb ar\n baz",
+			"foo    \nb   ar   ",
+			"foo\nb\nar",
 			4,
 		},
+		// An explicit line break at the end of the input is preserved.
 		{
-			" This is a list:\n\n\t* foo\n\t* bar\n\n\n\t* baz\nBAM",
-			" This\nis a\nlist:\n\n\t* foo\n\t* bar\n\n\n\t* baz\nBAM",
+			"foo bar baz\n",
+			"foo\nbar\nbaz\n",
 			4,
+		},
+		// Explicit break are always preserved.
+		{
+			"\nfoo bar\n\n\nbaz\n",
+			"\nfoo\nbar\n\n\nbaz\n",
+			4,
+		},
+		// Complete example:
+		{
+			" This is a list: \n\n\t* foo\n\t* bar\n\n\n\t* baz  \nBAM    ",
+			" This\nis a\nlist: \n\n\t* foo\n\t* bar\n\n\n\t* baz\nBAM",
+			6,
 		},
 	}
 
-	for _, tc := range cases {
+	for i, tc := range cases {
 		actual := WrapString(tc.Input, tc.Lim)
 		if actual != tc.Output {
-			t.Fatalf("Input:\n\n%s\n\nActual Output:\n\n%s", tc.Input, actual)
+			t.Fatalf("Case %d Input:\n\n`%s`\n\nActual Output:\n\n`%s`", i, tc.Input, actual)
 		}
 	}
 }

--- a/wordwrap_test.go
+++ b/wordwrap_test.go
@@ -5,9 +5,9 @@ import (
 )
 
 func TestWrapString(t *testing.T) {
-	cases := []struct{
+	cases := []struct {
 		Input, Output string
-		Lim uint
+		Lim           uint
 	}{
 		{
 			"foo",


### PR DESCRIPTION
I've changed the algorithm to break lines before hitting the width limit, rather than immediately after. AFAICT, this is more in line with what other hard-wrapping implementations do.

For example:

```go
wrapped := wordwrap.WrapString("foo s bar baz", 3)
fmt.Println(wrapped)
```

Before:
```
foo
s bar
baz
```

After:
```
foo
s
bar
baz
```

I also took care to preserve whitespace to the extent that is possible. The rationale being that this process should only make the minimum mutations to the text in order to fit within the given width, and should otherwise leave it alone.

I added a bunch more test cases which illustrate all of the edge cases I could think of.