### PR TITLE
Fix for producing output in length equal to input

### DIFF
--- a/wordwrap.go
+++ b/wordwrap.go
@@ -11,7 +11,7 @@ import (
 // version of the library will implement smarter wrapping. This means that
 // pathological cases can dramatically reach past the limit, such as a very
 // long word.
-func WrapString(s string, lim uint) string {
+func WrapString(s string, lim uint, equalLen bool) string {
 	// Initialize a buffer with a slightly larger size to account for breaks
 	init := make([]byte, 0, len(s))
 	buf := bytes.NewBuffer(init)
@@ -53,6 +53,10 @@ func WrapString(s string, lim uint) string {
 			wordBuf.WriteRune(char)
 
 			if current+uint(spaceBuf.Len()+wordBuf.Len()) > lim && uint(wordBuf.Len()) < lim {
+				if equalLen {
+					spaceBuf.ReadByte()
+					spaceBuf.WriteTo(buf)
+				}
 				buf.WriteRune('\n')
 				current = 0
 				spaceBuf.Reset()

--- a/wordwrap_test.go
+++ b/wordwrap_test.go
@@ -77,7 +77,7 @@ func TestWrapString(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		actual := WrapString(tc.Input, tc.Lim)
+		actual := WrapString(tc.Input, tc.Lim, false)
 		if actual != tc.Output {
 			t.Fatalf("Case %d Input:\n\n`%s`\n\nActual Output:\n\n`%s`", i, tc.Input, actual)
 		}


### PR DESCRIPTION
Fix for scenarios where wordwrap might be used inside a wrapper writer that expects equal length input and output bytes to avoid ErrShortWrite error.